### PR TITLE
Colophon

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -3,11 +3,15 @@ coffee = require 'gulp-coffee'
 util   = require 'gulp-util'
 
 gulp.task 'coffee', ->
-  gulp.src './src/*.coffee'
+  gulp.src './src/**/*.coffee'
     .pipe coffee({bare: true}).on('error', util.log)
     .pipe gulp.dest('./lib/')
 
-gulp.task 'watch', ->
-  gulp.watch './src/*', ['coffee']
+gulp.task 'mustache', ->
+  gulp.src './src/views/*.mustache'
+    .pipe gulp.dest('./lib/views/')
 
-gulp.task 'default', ['coffee', 'watch']
+gulp.task 'watch', ->
+  gulp.watch './src/**/*', ['coffee', 'mustache']
+
+gulp.task 'default', ['coffee', 'mustache', 'watch']

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "make test"
   },
   "dependencies": {
+    "cheerio": "^0.18.0",
     "consolidate": "^0.10.0",
     "express": "^4.10.6",
     "gulp-util": "^3.0.1",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -18,6 +18,8 @@ module.exports =
     app = express()
     app.use express.static config.dist
     storefront.set 'store_id', config.store_id
-    storefront.set 'views', config.src
+    views = storefront.get 'views'
+    views.push config.src
+    storefront.set 'views', views
     app.use storefront
     app.listen config.port, -> util.log "Serving your awesome theme at http://localhost:#{config.port}/"

--- a/src/middlewares/partials.coffee
+++ b/src/middlewares/partials.coffee
@@ -8,7 +8,7 @@ module.exports = (req, res, next) ->
   data =
     partials: {}
 
-  _.each fs.readdirSync(req.app.get 'views'), (path) ->
+  _.each fs.readdirSync(req.app.get('views')[1]), (path) ->
     match = (/(.*)\.mustache/g).exec path
     if !match or (match && match[1] is 'theme')
       return

--- a/src/middlewares/render.coffee
+++ b/src/middlewares/render.coffee
@@ -25,65 +25,10 @@ module.exports = (req, res) ->
 
       res.render 'theme', context, (err, html) ->
         $ = cheerio.load html
-        $('body').append '<iframe
-          name="tt_colophon"
-          id="tt_colophon"
-          src="https://tictail.com/cart/'+context.store_subdomain+'"
-          style="
-            position: fixed;
-            z-index: 9999;
-            top: 0;
-            right: 0;
-            height: 37px;
-            overflow: hidden;
-            background: none;
-            border: 0;
-          "></iframe>'
-        $('body').append '<script>
-          var __ttBaseUrl = "https://tictail.com",
-          __ttColophonUrl = "https://tictail.com/cart/'+context.store_subdomain+'",
-          __ttSearchUrl = "http://'+context.store_subdomain+'.tictail.com/search",
-          __ttAssetsUrl = "//app.ttcdn.co/theme_assets",
-          __ttLocaleData = {"": {"domain": "storefront", "locale": "sv", "plural_forms": "nplurals=2; plural=(n != 1);"}, "An unexpected error occurred. Please try again.": [null, "Ett oväntat fel inträffade. Var god försök igen."], "No products found": [null, "Inga produkter hittades"], "Out of stock": [null, "Ej i lager"], "Please enter a valid email address.": [null, "Ange en giltig e-postadress."], "Quantity": [null, "Antal"], "Remove": [null, "Ta bort"], "Searching...": [null, "Söker..."]},
-          __ttSubdomain = "'+context.store_subdomain+'",
-          __ttAnalyticsId = "UA-000000-01",
-          __ttSession = {
-            "track": {
-              "storefront_utm_medium": null,
-              "storefront_utm_content": null,
-              "storefront_utm_source": null,
-              "storefront_utm_term": null,
-              "storefront_utm_campaign": null
-            },
-            "behaviors": {
-              "respect_browser_locale": false
-            },
-            "cdn": "none",
-            "experiments": {}
-          };
-        </script>
-        <script src="//dmb7ixdwya1nh.cloudfront.net/static/js/v1/storefront/json.v-ec33eba9f2.js"></script>
-        <script src="//dmb7ixdwya1nh.cloudfront.net/static/js/storefront/mustache.v-b5febf1682.js"></script>
-        <script src="//dmb7ixdwya1nh.cloudfront.net/static/js/storefront/store.v-fd121f6f72.js"></script>
-        <script>TT.store.domReady();</script>'
-        $('body').append '<a
-          id="__ttLogo"
-          style="
-            position: absolute;
-            bottom: 10px;
-            right: 15px;
-          "
-          href="https://tictail.com"
-          target="_blank"
-        ><img
-          src="//dmb7ixdwya1nh.cloudfront.net/static/i/storefront/tictail-logo.v-f7194876c2.png"
-          alt="Tictail"
-          style="
-            width: 42px;
-            opacity: 0.25;
-          "
-        ></a>'
-        res.send $.html()
+        context.partials = {} # fixes the context modifications made by consolidate.js
+        req.app.render 'colophon', context, (err, colophon) ->
+          $('body').append colophon
+          res.send $.html()
     .fail (err) ->
       status = switch err.constructor
         when HTTPError
@@ -93,4 +38,4 @@ module.exports = (req, res) ->
           console.log err.stack
           500
 
-      res.status(status).send("<code>#{status}</code>")
+      res.status(status).send "<code>#{status}</code>"

--- a/src/middlewares/render.coffee
+++ b/src/middlewares/render.coffee
@@ -1,6 +1,7 @@
 Q = require 'q'
 merge = require 'merge'
 HTTPError = require 'node-http-error'
+cheerio = require 'cheerio'
 
 
 module.exports = (req, res) ->
@@ -22,7 +23,67 @@ module.exports = (req, res) ->
             context.list_page.current_navigation = subcategory
             break
 
-      res.render 'theme', context
+      res.render 'theme', context, (err, html) ->
+        $ = cheerio.load html
+        $('body').append '<iframe
+          name="tt_colophon"
+          id="tt_colophon"
+          src="https://tictail.com/cart/'+context.store_subdomain+'"
+          style="
+            position: fixed;
+            z-index: 9999;
+            top: 0;
+            right: 0;
+            height: 37px;
+            overflow: hidden;
+            background: none;
+            border: 0;
+          "></iframe>'
+        $('body').append '<script>
+          var __ttBaseUrl = "https://tictail.com",
+          __ttColophonUrl = "https://tictail.com/cart/'+context.store_subdomain+'",
+          __ttSearchUrl = "http://'+context.store_subdomain+'.tictail.com/search",
+          __ttAssetsUrl = "//app.ttcdn.co/theme_assets",
+          __ttLocaleData = {"": {"domain": "storefront", "locale": "sv", "plural_forms": "nplurals=2; plural=(n != 1);"}, "An unexpected error occurred. Please try again.": [null, "Ett oväntat fel inträffade. Var god försök igen."], "No products found": [null, "Inga produkter hittades"], "Out of stock": [null, "Ej i lager"], "Please enter a valid email address.": [null, "Ange en giltig e-postadress."], "Quantity": [null, "Antal"], "Remove": [null, "Ta bort"], "Searching...": [null, "Söker..."]},
+          __ttSubdomain = "'+context.store_subdomain+'",
+          __ttAnalyticsId = "UA-000000-01",
+          __ttSession = {
+            "track": {
+              "storefront_utm_medium": null,
+              "storefront_utm_content": null,
+              "storefront_utm_source": null,
+              "storefront_utm_term": null,
+              "storefront_utm_campaign": null
+            },
+            "behaviors": {
+              "respect_browser_locale": false
+            },
+            "cdn": "none",
+            "experiments": {}
+          };
+        </script>
+        <script src="//dmb7ixdwya1nh.cloudfront.net/static/js/v1/storefront/json.v-ec33eba9f2.js"></script>
+        <script src="//dmb7ixdwya1nh.cloudfront.net/static/js/storefront/mustache.v-b5febf1682.js"></script>
+        <script src="//dmb7ixdwya1nh.cloudfront.net/static/js/storefront/store.v-fd121f6f72.js"></script>
+        <script>TT.store.domReady();</script>'
+        $('body').append '<a
+          id="__ttLogo"
+          style="
+            position: absolute;
+            bottom: 10px;
+            right: 15px;
+          "
+          href="https://tictail.com"
+          target="_blank"
+        ><img
+          src="//dmb7ixdwya1nh.cloudfront.net/static/i/storefront/tictail-logo.v-f7194876c2.png"
+          alt="Tictail"
+          style="
+            width: 42px;
+            opacity: 0.25;
+          "
+        ></a>'
+        res.send $.html()
     .fail (err) ->
       status = switch err.constructor
         when HTTPError

--- a/src/storefront.coffee
+++ b/src/storefront.coffee
@@ -6,6 +6,7 @@ Api = require './api'
 app = express()
 app.engine 'mustache', consolidate.mustache
 app.set 'view engine', 'mustache'
+app.set 'views', [__dirname + '/views']
 app.set 'api', new Api()
 app.disable 'etag'
 

--- a/src/views/colophon.mustache
+++ b/src/views/colophon.mustache
@@ -1,0 +1,61 @@
+<iframe
+  name="tt_colophon"
+  id="tt_colophon"
+  src="https://tictail.com/cart/{{store_subdomain}}"
+  style="
+    position: fixed;
+    z-index: 9999;
+    top: 0;
+    right: 0;
+    height: 37px;
+    overflow: hidden;
+    background: none;
+    border: 0;
+  "
+></iframe>
+
+<script>
+  var __ttBaseUrl = "https://tictail.com",
+  __ttColophonUrl = "https://tictail.com/cart/{{store_subdomain}}",
+  __ttSearchUrl = "http://{{store_subdomain}}.tictail.com/search",
+  __ttAssetsUrl = "//app.ttcdn.co/theme_assets",
+  __ttLocaleData = {},
+  __ttSubdomain = "{{store_subdomain}}",
+  __ttAnalyticsId = "UA-000000-01",
+  __ttSession = {
+    "track": {
+      "storefront_utm_medium": null,
+      "storefront_utm_content": null,
+      "storefront_utm_source": null,
+      "storefront_utm_term": null,
+      "storefront_utm_campaign": null
+    },
+    "behaviors": {
+      "respect_browser_locale": false
+    },
+    "cdn": "none",
+    "experiments": {}
+  };
+</script>
+<script src="//dmb7ixdwya1nh.cloudfront.net/static/js/v1/storefront/json.v-ec33eba9f2.js"></script>
+<script src="//dmb7ixdwya1nh.cloudfront.net/static/js/storefront/mustache.v-b5febf1682.js"></script>
+<script src="//dmb7ixdwya1nh.cloudfront.net/static/js/storefront/store.v-fd121f6f72.js"></script>
+<script>TT.store.domReady();</script>
+
+<a
+  id="__ttLogo"
+  style="
+    position: absolute;
+    bottom: 10px;
+    right: 15px;
+  "
+  href="https://tictail.com"
+  target="_blank"
+><img
+  src="//dmb7ixdwya1nh.cloudfront.net/static/i/storefront/tictail-logo.v-f7194876c2.png"
+  alt="Tictail"
+  style="
+    width: 42px;
+    opacity: 0.25;
+  "
+></a>

--- a/test/app_spec.coffee
+++ b/test/app_spec.coffee
@@ -5,7 +5,9 @@ storefront = require '../lib/storefront'
 storefront.set 'store_id', 't'
 
 
-storefront.set('views', __dirname)
+views = storefront.get 'views'
+views.push __dirname
+storefront.set 'views', views
 
 describe 'Storefront', ->
   it 'should get /', (done) ->


### PR DESCRIPTION
This inserts the Tictail colophon and other markup/scripts into the body element of the rendered view, before sending the final response body.

* Colophon iframe
* TT JavaScript
* Tictail bottom right logotype

![screen shot 2015-01-20 at 10 31 31](https://cloud.githubusercontent.com/assets/200250/5814787/946121d2-a08f-11e4-8dcc-c463117d6612.png)

PS. The colophon will throw client side errors and won't work due to `localhost` not matching the store domain (CORS). I think this is fine for the purpose of `gulp-tictail`. DS.