### PR TITLE
Add option to set filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tictail",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Gulp target for simplifying Tictail theme creation.",
   "license": "MIT",
   "repository": "https://github.com/tictail/gulp-tictail.git",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -56,7 +56,10 @@ module.exports =
       )
 
     fs.mkdirSync(config.dist) unless fs.existsSync(config.dist)
-    fs.writeFileSync "#{config.dist}/theme.mustache", theme
-    util.log "Theme written to #{config.dist}/theme.mustache"
+
+    fileName = config.fileName or 'theme'
+    fs.writeFileSync "#{config.dist}/#{fileName}.html", theme
+
+    util.log "Theme written to #{config.dist}/theme.html"
 
     # TODO: Possible to return stream?


### PR DESCRIPTION
This PR add the option to specify a filename for the built file.

Usage:
```
tictail.build({
  fileName: 'foobar'
})
```

Output:
```
foobar.html
```